### PR TITLE
global grunt bin cannot find bug fix

### DIFF
--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -27,6 +27,7 @@ module.exports = function(grunt) {
 
   // Find the grunt bin
   var gruntBin = grunt.util._.find([
+    process.argv[1],
     path.resolve(process.cwd(), 'node_modules', '.bin', 'grunt'),
     path.resolve(path.dirname(process.execPath), 'grunt'),
     path.resolve(__dirname, '..', 'node_modules', '.bin', 'grunt'),


### PR DESCRIPTION
I find the method of grunt bin finding have some bugs, so I solved it without installing grunt in locally again, and instead of using global grunt bin easily.
