### PR TITLE
Pass changed files to spawned tasks as cli parameter

### DIFF
--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -78,9 +78,6 @@ module.exports = function(grunt) {
           grunt.log.ok('File "' + filepath + '" ' + changedFiles[filepath] + '.');
         });
 
-        // Reset changedFiles
-        changedFiles = Object.create(null);
-
         // Spawn the tasks as a child process
         spawned[i] = grunt.util.spawn({
           // Spawn with the grunt bin
@@ -88,12 +85,16 @@ module.exports = function(grunt) {
           // Run from current working dir and inherit stdio from process
           opts: {cwd: process.cwd(), stdio: 'inherit'},
           // Run grunt this process uses, append the task to be run and any cli options
-          args: grunt.util._.union(tasks, cliArgs)
+          args: grunt.util._.union(tasks, cliArgs).concat(['--changed=' + JSON.stringify(changedFiles)])
         }, function(err, res, code) {
           // Spawn is done
           delete spawned[i];
           grunt.log.writeln('').write(waiting);
         });
+
+        // Reset changedFiles
+        changedFiles = Object.create(null);
+
       }
     }, 250);
 


### PR DESCRIPTION
I found a workaround for grunt.file.watchFiles since it was pulled out and we have sandboxed tasks now (see #14). In addition to passing the current cli options, this will add a JSON.stringify'd object of the changes as `--changed={'style.css':'changed'}`. 
