### PR TITLE
Debounce runTasks for each target individually

### DIFF
--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -60,7 +60,7 @@ module.exports = function(grunt) {
     grunt.log.write(waiting);
 
     // Run the tasks for the changed files
-    var runTasks = grunt.util._.debounce(function runTasks(i, tasks, options) {
+    var runTasks = function runTasks(i, tasks, options) {
       // If interrupted, reset the spawned for a target
       if (options.interrupt && typeof spawned[i] === 'object') {
         grunt.log.writeln('').write('Previously spawned task has been interrupted...'.yellow);
@@ -102,7 +102,7 @@ module.exports = function(grunt) {
           grunt.log.writeln('').write(msg + ' - ' + waiting);
         });
       }
-    }, 250);
+    };
 
     targets.forEach(function(target, i) {
       if (typeof target.files === 'string') {
@@ -124,11 +124,13 @@ module.exports = function(grunt) {
           return done();
         }
 
+        var runTasksDebounced = grunt.util._.debounce(runTasks, 250);
+
         // On changed/added/deleted
         this.on('all', function(status, filepath) {
           filepath = path.relative(process.cwd(), filepath);
           changedFiles[filepath] = status;
-          runTasks(i, target.tasks, options);
+          runTasksDebounced(i, target.tasks, options);
         });
 
         // On watcher error

--- a/test/tasks/watch_test.js
+++ b/test/tasks/watch_test.js
@@ -53,13 +53,27 @@ exports.watchConfig = {
       test.done();
     });
   },
-  multiTargetsTriggerBoth: function(test) {
+  multiTargetsSequentialFilesChangeTriggerBoth: function(test) {
     test.expect(2);
     var cwd = path.resolve(fixtures, 'multiTargets');
     var assertWatch = helper.assertTask('watch', {cwd:cwd});
     assertWatch([function() {
       grunt.file.write(path.join(cwd, 'lib', 'one.js'), 'var test = true;');
     }, function() {
+      grunt.file.write(path.join(cwd, 'lib', 'two.js'), 'var test = true;');
+    }], function(result) {
+      helper.verboseLog(result);
+      test.ok(result.indexOf('one has changed') !== -1, 'Task echo:one should of emit.');
+      test.ok(result.indexOf('two has changed') !== -1, 'Task echo:two should of emit.');
+      test.done();
+    });
+  },
+  multiTargetsSimultaneousFilesChangeTriggerBoth: function(test) {
+    test.expect(2);
+    var cwd = path.resolve(fixtures, 'multiTargets');
+    var assertWatch = helper.assertTask('watch', {cwd:cwd});
+    assertWatch([function() {
+      grunt.file.write(path.join(cwd, 'lib', 'one.js'), 'var test = true;');
       grunt.file.write(path.join(cwd, 'lib', 'two.js'), 'var test = true;');
     }], function(result) {
       helper.verboseLog(result);


### PR DESCRIPTION
Now, if simultaneous (or near-simultaneous) file changes will trigger multiple targets, all
targets execute instead of just one target.

![Screen Shot 2013-02-23 at 11 32 30 AM](https://f.cloud.github.com/assets/1527302/188512/56e0830a-7df2-11e2-8058-9af72f28bba7.png)
