### PR TITLE
Resolves (or should I say works around?) issue #25: when multiple tasks ...

### DIFF
--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -135,11 +135,15 @@ module.exports = function(grunt) {
           }
 
           // Run tasks if any have been specified
-          if (target.tasks) {
-            changedFiles[filepath] = status;
-            taskrun.queue(target.name);
-            taskrun.run();
-          }
+          changedFiles[filepath] = status;
+
+          targets.forEach(function (target, i) {
+            if (target.tasks && grunt.file.isMatch(target.files, filepath)) {
+              taskrun.queue(target.name);
+            }
+          });
+
+          taskrun.run();
         });
 
         // On watcher error


### PR DESCRIPTION
@shama here's my attempt to resolve #25. On a watched change, the task loops through each available target, and queues up each task whose file parameters match the incoming filepath.

Apologies for missing tests. I didn't know the best way to test this fix. It does work in my local testing however.
