### PR TITLE
Fix for watchers closing.

### DIFF
--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -66,8 +66,8 @@ module.exports = function(grunt) {
     // Close any previously opened watchers
     watchers.forEach(function(watcher, i) {
       watcher.close();
-      watchers.splice(i, 1);
     });
+    watchers = [];
 
     // Never gonna give you up, never gonna let you down
     if (grunt.config([name, 'options', 'forever']) !== false) {


### PR DESCRIPTION
Iterated array should never be modified during iteration, http://jsfiddle.net/9t64K/1.
