### PR TITLE
EMFILE FAQ - alternate fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ Since live reloading is used when developing, you may want to disable building f
 #### How do I fix the error `EMFILE: Too many opened files.`?
 This is because of your system's max opened file limit. For OSX the default is very low (256). Temporarily increase your limit with `ulimit -n 10480`, the number being the new max limit.
 
+In some versions of OSX the above won't work. In that case do `launchctl limit maxfiles 10480 10480 ` and restart terminal. See [here](http://superuser.com/questions/261023/how-to-change-default-ulimit-values-in-mac-os-x-10-6).
+
 #### Can I use this with Grunt v0.3?
 Yes. Although `grunt-contrib-watch` is a replacement watch task for Grunt v0.4, version `grunt-contrib-watch@0.1.x` is compatible with Grunt v0.3. `grunt-contrib-watch >= 0.2.x` is **only* compatible and recommended to use with Grunt v0.4.
 


### PR DESCRIPTION
In some versions of OSX `ulimit` will not work. The max file limit is
controlled via `launchctl`.
