### PR TITLE
don't catch SIGINT unless watch task is invoked

### DIFF
--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -52,15 +52,15 @@ module.exports = function(grunt) {
     grunt.log.writeln('').writeln('Reloading watch config...'.cyan);
   });
 
-  // On shutdown, close up watchers
-  process.on('SIGINT', function() {
-    grunt.log.writeln('').write('Shutting down the watch task...').ok();
-    process.exit();
-  });
-
   grunt.registerTask('watch', 'Run predefined tasks whenever watched files change.', function(target) {
     var self = this;
     var name = self.name || 'watch';
+
+    // On shutdown, close up watchers
+    process.on('SIGINT', function() {
+      grunt.log.writeln('').write('Shutting down the watch task...').ok();
+      process.exit();
+    });
 
     // Close any previously opened watchers
     watchers.forEach(function(watcher, i) {


### PR DESCRIPTION
this just moves the `process.on('SIGINT', ...)` block inside the task
callback. the problem is that it currently handles SIGINT even when the
task isn't being run, which could affect other tasks that want to use
that signal.

i ran the 'jshint' and 'nodeunit' tasks, and this doesn't seem to have
broken anything.
