### PR TITLE
Add atBegin option to run tasks when watcher starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ Default: true
 
 This is *only a task level option* and cannot be configured per target. By default the watch task will duck punch `grunt.fatal` and `grunt.warn` to try and prevent them from exiting the watch process. If you don't want `grunt.fatal` and `grunt.warn` to be overridden set the `forever` option to `false`.
 
+#### options.atBegin
+Type: `Boolean`
+Default: false
+
+This option will trigger the run of each specified task at startup of the watcher.
+
 #### options.livereload
 Type: `Boolean|Number|Object`
 Default: false
@@ -363,4 +369,4 @@ Spawning does cause a performance hit (usually 500ms for most environments). It 
 
 Task submitted by [Kyle Robinson Young](http://dontkry.com)
 
-*This file was generated on Thu May 30 2013 15:12:52.*
+*This file was generated on Sun Jul 07 2013 14:50:23.*

--- a/docs/watch-options.md
+++ b/docs/watch-options.md
@@ -100,6 +100,12 @@ Default: true
 
 This is *only a task level option* and cannot be configured per target. By default the watch task will duck punch `grunt.fatal` and `grunt.warn` to try and prevent them from exiting the watch process. If you don't want `grunt.fatal` and `grunt.warn` to be overridden set the `forever` option to `false`.
 
+## options.atBegin
+Type: `Boolean`
+Default: false
+
+This option will trigger the run of each specified task at startup of the watcher.
+
 ## options.livereload
 Type: `Boolean|Number|Object`
 Default: false

--- a/tasks/lib/taskrunner.js
+++ b/tasks/lib/taskrunner.js
@@ -86,6 +86,15 @@ module.exports = function(grunt) {
       self.run();
     }
 
+    if(self.options.atBegin){
+      setTimeout(function(){
+        self.queue = self._getTargets(self.name).map(function(tr){
+          return tr.name;
+        });
+        self.run();
+      }, 100);
+    }
+
     // Return the targets normalized
     return self._getTargets(self.name);
   };

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -73,6 +73,7 @@ module.exports = function(grunt) {
     var targets = taskrun.init(name, {
       interrupt: false,
       nospawn: false,
+      atBegin: false,
       event: ['all'],
       target: target,
     });

--- a/test/fixtures/atBegin/Gruntfile.js
+++ b/test/fixtures/atBegin/Gruntfile.js
@@ -1,0 +1,22 @@
+module.exports = function(grunt) {
+  'use strict';
+  grunt.initConfig({
+    echo: {
+      one: { message: 'one has changed' }
+    },
+    watch: {
+      options:{
+        atBegin: true
+      },
+      one: {
+        files: ['lib/one.js', 'Gruntfile.js'],
+        tasks: 'echo:one',
+      }
+    }
+  });
+  // Load the echo task
+  grunt.loadTasks('../tasks');
+  // Load this watch task
+  grunt.loadTasks('../../../tasks');
+  grunt.registerTask('default', ['echo']);
+};

--- a/test/fixtures/atBegin/lib/one.js
+++ b/test/fixtures/atBegin/lib/one.js
@@ -1,0 +1,1 @@
+var test = true;

--- a/test/tasks/watch_test.js
+++ b/test/tasks/watch_test.js
@@ -26,6 +26,20 @@ exports.watchConfig = {
     cleanUp();
     done();
   },
+  atBegin: function(test) {
+    test.expect(1);
+    var cwd = path.resolve(fixtures, 'atBegin');
+    var assertWatch = helper.assertTask(['watch', '--debug'], {cwd:cwd});
+    assertWatch(function() {
+       // noop. Does not modify any watched files.
+    }, function(result) {
+      helper.verboseLog(result);
+      var firstIndex = result.indexOf('one has changed');
+      test.ok(firstIndex !== -1, 'Watch should have fired even though no file was changed.');
+      test.done();
+    });
+
+  },
   oneTarget: function(test) {
     test.expect(2);
     var cwd = path.resolve(fixtures, 'oneTarget');


### PR DESCRIPTION
I've added a new option to this task that will run all of the tasks when the watcher starts. In order to test this, I had to leak some information out of the assertTask helper because there was no way to cancel the watching without changing a file. I'd love to have a better way to do that, so let me know if you have any thoughts on how to change that. 
