### PR TITLE
Added ability to pass last-modified file as option to spawned proc

### DIFF
--- a/tasks/lib/taskrun.js
+++ b/tasks/lib/taskrun.js
@@ -47,6 +47,10 @@ module.exports = function(grunt) {
       grunt.task.run(self.tasks);
       done();
     } else {
+      var args = self.tasks.concat(self.options.cliArgs || []);
+      if(self.options.fileAsArg) {
+        args.push('--file=' + Object.keys(self.changedFiles)[0]);
+      }
       self.spawned = grunt.util.spawn({
         // Spawn with the grunt bin
         grunt: true,
@@ -56,7 +60,7 @@ module.exports = function(grunt) {
           stdio: 'inherit',
         },
         // Run grunt this process uses, append the task to be run and any cli options
-        args: self.tasks.concat(self.options.cliArgs || [])
+        args: args
       }, function(err, res, code) {
         // Spawn is done
         self.spawned = null;


### PR DESCRIPTION
Added option to use `fileAsArg: true` to pass file as argument to spawned tasks. This hopefully removes the most common usecase for `nospawn: true` and thus lets people avoid a lot of the bugs that can be encountered when using it. References #148 and #150. 

Tasks that need it can then access it with `grunt.option('file')` as oposed to `this.data.file` set by the watchers. This also helps keep the Gruntfile cleaner.

If you like this sort of implementation, I can probably write tests. However if the maintainers don't like the feature then I wont bother. Let me know if you think you might merge it in.
