### PR TITLE
`interrupt` should work more than once

### DIFF
--- a/tasks/lib/taskrun.js
+++ b/tasks/lib/taskrun.js
@@ -58,9 +58,11 @@ module.exports = function(grunt) {
         // Run grunt this process uses, append the task to be run and any cli options
         args: self.tasks.concat(self.options.cliArgs || [])
       }, function(err, res, code) {
-        // Spawn is done
-        self.spawned = null;
-        done();
+        if (self.options.interrupt !== true || code !== 130) {
+          // Spawn is done
+          self.spawned = null;
+          done();
+        }
       });
     }
   };

--- a/test/fixtures/multiTargets/Gruntfile.js
+++ b/test/fixtures/multiTargets/Gruntfile.js
@@ -5,7 +5,7 @@ module.exports = function(grunt) {
       one: { message: 'one has changed' },
       two: { message: 'two has changed' },
       wait: { message: 'I waited 2s', wait: 2000 },
-      interrupt: { message: 'I want to be interrupted', wait: 5000 },
+      interrupt: { message: 'I want to be interrupted', wait: 3000 },
       fail: { fail: 1, message: 'This task should fail' }
     },
     watch: {

--- a/test/fixtures/multiTargets/lib/interrupt.js
+++ b/test/fixtures/multiTargets/lib/interrupt.js
@@ -1,1 +1,1 @@
-var interrupt = true;
+var interrupt = 3;

--- a/test/tasks/watch_test.js
+++ b/test/tasks/watch_test.js
@@ -113,17 +113,23 @@ exports.watchConfig = {
     });
   },
   interrupt: function(test) {
-    test.expect(1);
+    test.expect(2);
     var cwd = path.resolve(fixtures, 'multiTargets');
     var assertWatch = helper.assertTask('watch', {cwd:cwd});
     assertWatch(function() {
-      grunt.file.write(path.join(cwd, 'lib', 'interrupt.js'), 'var interrupt = false;');
+      grunt.file.write(path.join(cwd, 'lib', 'interrupt.js'), 'var interrupt = 1;');
       setTimeout(function() {
-        grunt.file.write(path.join(cwd, 'lib', 'interrupt.js'), 'var interrupt = true;');
+        grunt.file.write(path.join(cwd, 'lib', 'interrupt.js'), 'var interrupt = 2;');
       }, 1000);
+      setTimeout(function() {
+        grunt.file.write(path.join(cwd, 'lib', 'interrupt.js'), 'var interrupt = 3;');
+      }, 2000);
     }, function(result) {
       helper.verboseLog(result);
-      test.ok(result.indexOf('have been interrupted') !== -1, 'Task should have been interrupted.');
+      var interruptMatches = result.match(/have been interrupted/g);
+      test.ok(interruptMatches && interruptMatches.length === 2, 'Task should have been interrupted 2 times.');
+      var unInterruptMatches = result.match(/I want to be interrupted/g);
+      test.ok(unInterruptMatches && unInterruptMatches.length === 1, 'Only the last time should be working (without interruption)');
       test.done();
     });
   },


### PR DESCRIPTION
Found that the current implementation of `interrupt` only work once, second time onward the `running` of Runner would be `false` (https://github.com/gruntjs/grunt-contrib-watch/blob/master/tasks/lib/taskrunner.js#L152). I believe the problem lies in `TaskRun.run()` calling `done()` upon all completion signal (https://github.com/gruntjs/grunt-contrib-watch/blob/master/tasks/lib/taskrun.js#L63), as in the case of `interrupt`, `TaskRun.complete()` would be triggered prior to actual completion of the "interrupted" task (https://github.com/gruntjs/grunt-contrib-watch/blob/master/tasks/lib/taskrun.js#L73). I am not sure if this is the right fix, but tested to work (see updated unit test).

The actual use case is something similar to the following:

The example use `grunt-contrib-watch` to monitor an `express.js` server file, restarts the server whenever it changes, it also uses `atBegin` to start the server initially. Noticed first time updates the `./server.js`, the server restarted, but second time (or onward) changing `./server.js` will result in error `EADDRINUSE` since `interrupt()` was never triggered.

``` javascript
var express = require('express');

module.exports = function(grunt) {
  grunt.loadNpmTasks('grunt-contrib-watch');

  grunt.initConfig({
    watch: {
      server: {
        files: './server.js',
        tasks: ['server'],
        options: {
          interrupt: true,
          atBegin: true
        }
      }
    });

  grunt.registerTask('server', function() {
    require('./server').listen(3000, function(err) {
      if (err) {
        grunt.log.writeln(err);
      } else {
        grunt.log.writeln('started');
      }
    });
    this.async();
  });

  // Default task(s).
  grunt.registerTask('default', ['watch']);
};
```
