### PR TITLE
Append watch.options.cliArgs on spawn

### DIFF
--- a/tasks/lib/taskrun.js
+++ b/tasks/lib/taskrun.js
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
 
   // Run it
   TaskRun.prototype.run = function(done) {
-    var self = this;
+    var self = this, args;
 
     // Dont run if already running
     if (self.startedAt !== false) { return; }
@@ -47,6 +47,10 @@ module.exports = function(grunt) {
       grunt.task.run(self.tasks);
       done();
     } else {
+      // Run grunt this process uses, append the task to be run and any cli options
+      args = self.tasks
+          .concat(self.options.cliArgs || [])
+          .concat(grunt.config(['watch', 'options', 'cliArgs']) || []);
       self.spawned = grunt.util.spawn({
         // Spawn with the grunt bin
         grunt: true,
@@ -55,8 +59,7 @@ module.exports = function(grunt) {
           cwd: self.options.cwd,
           stdio: 'inherit',
         },
-        // Run grunt this process uses, append the task to be run and any cli options
-        args: self.tasks.concat(self.options.cliArgs || [])
+        args: args
       }, function(err, res, code) {
         // Spawn is done
         self.spawned = null;


### PR DESCRIPTION
Currently cliArgs was fetched once on watch task startup. This means that event
handlers can not change that afterwords. Now every time grunt is spawned it can
have different command line arguments.
