### PR TITLE
Fixed syntax error in options.dateFormat example

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ This is *only a task level option* and cannot be configured per target. By defau
 watch: {
   options: {
     dateFormat: function(time) {
-      grunt.log.writeln('The watch finished in ' + time + 'ms at' + (new Date()).toString()));
+      grunt.log.writeln('The watch finished in ' + time + 'ms at' + (new Date()).toString());
       grunt.log.writeln('Waiting for more changes...');
     },
   },


### PR DESCRIPTION
By the way, I didn't find this error by hand. I made a tool called [mdlint](https://github.com/ChrisWren/mdlint) that validates JavaScript code blocks in markdown files. Check it out if you want to lint READMEs, docs, or blog posts!
