### PR TITLE
Clear changedFiles after triggering livereload

### DIFF
--- a/tasks/lib/taskrun.js
+++ b/tasks/lib/taskrun.js
@@ -76,6 +76,7 @@ module.exports = function(grunt) {
     // Trigger livereload if set
     if (this.livereload) {
       this.livereload.trigger(Object.keys(this.changedFiles));
+      this.changedFiles = Object.create(null);
     }
     return time;
   };


### PR DESCRIPTION
Livereload was being triggered for files which had been changed earlier.

For instance, a change to `somefile.html` would trigger livereload and the page would refresh. If `somefile.css` was changed some time later, the livereload would get triggered for both files, which would make the page refresh rather than just injecting the new CSS.

This seems to have fixed it. Couldn't really run the tests because I'm stuck with Windows.
