### PR TITLE
extending livereload https support to include option for reading in ca file

### DIFF
--- a/tasks/lib/livereload.js
+++ b/tasks/lib/livereload.js
@@ -31,6 +31,9 @@ module.exports = function(grunt) {
       if (options.key && options.cert) {
         options.key = grunt.file.read(options.key);
         options.cert = grunt.file.read(options.cert);
+        if (options.ca) {
+          options.ca = grunt.file.read(options.ca);
+        }
       }
 
       this.server = tinylr(options);


### PR DESCRIPTION
I feel that if we are going to read in the key and cert files from path (provided by user) we should also be able to accept the ca file path for reading in as well.

This pull request extends the one made by @joeybaker to enable livereload over https: https://github.com/gruntjs/grunt-contrib-watch/pull/197

However, i have noticed a common trend with grunt modules; in that the modules typically expect the user to provide a string for the key|cert|ca instead of providing a path and having the module read the file in. I see this as being more flexible as the key|cert|ca may not always exist in a file. 

So, oddly enough, in conclusion i would actually suggest not pulling this merge and actually removing the previous (https://github.com/gruntjs/grunt-contrib-watch/pull/197). Allowing for the user to pass key|cert|ca strings through grunt-contrib-watch to tiny-lr.

Thanks and sorry if this PR is confusing. Just trying to make it easy if you should opt to extend the PR made by @joeybaker
