### PR TITLE
Print a newline after the initial Waiting...

### DIFF
--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -78,7 +78,7 @@ module.exports = function(grunt) {
       dateFormat = df;
     }
 
-    if (taskrun.running === false) { grunt.log.write(waiting); }
+    if (taskrun.running === false) { grunt.log.writeln(waiting); }
 
     // initialize taskrun
     var targets = taskrun.init(name, {target: target});


### PR DESCRIPTION
Things like foreman doesn't work very well when a line without a newline
is printed, it blocks the output from all other processes so that the
lines may come in order.
