### PR TITLE
Update FAQ for how to serve static files to the server

### DIFF
--- a/docs/watch-examples.md
+++ b/docs/watch-examples.md
@@ -220,3 +220,8 @@ The goal of this watch task is as files are changed, run tasks as if they were t
 Sandboxing task runs also allows this watch task to run more stable over long periods of time. As well as more efficiently with more complex tasks and file structures.
 
 Spawning does cause a performance hit (usually 500ms for most environments). It also cripples tasks that rely on the watch task to share the context with each subsequent run (i.e., reload tasks). If you would like a faster watch task or need to share the context please set the `spawn` option to `false`. Just be aware that with this option enabled, the watch task is more prone to failure.
+
+## How can I have the browser reload for files listed in a task?
+Instead of restarting your server each time a static file is changed, start a static web server using (grunt-contrib-connect)[https://github.com/gruntjs/grunt-contrib-connect].
+
+You'll have the `connect` web server on seperate port ex: port 9000 from your main server. When the 'livereload' option is enabled for 'watch' tasks, it will handle triggerring the live reload server for each tasks and when files are modified, which then server back to main server ex: 3000. The main server must include a script tag or a browser extension to the livereload server in order for the browser automatically.


### PR DESCRIPTION
Adds to the documentation how to enable your watched files to be served to your static filer so and start the Live Reload server to trigger those files.