### PR TITLE
replace greedy !**/node_modules/** pattern and added note about similar folders to be ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ In some versions of OSX the above solution doesn't work. In that case try `launc
 `grunt-contrib-watch@0.1.x` is compatible with Grunt v0.3 but it is highly recommended to upgrade Grunt instead.
 
 #### Why is the watch devouring all my memory/cpu?
-Likely because of an enthusiastic pattern trying to watch thousands of files. Such as `'**/*.js'` but forgetting to exclude the `node_modules` folder with `'!node_modules'`. Try grouping your files within a subfolder or be more explicit with your file matching pattern.
+Likely because of an enthusiastic pattern trying to watch thousands of files. Such as `'**/*.js'` but forgetting to exclude the `node_modules` folder with `'!node_modules'`  (also try `'!.git'`, `'!bower_components'` and other utilitarian folders). Try grouping your files within a subfolder or be more explicit with your file matching pattern.
 
 Another reason if you're watching a large number of files could be the low default `interval`. Try increasing with `options: { interval: 5007 }`. Please see issues [#35](https://github.com/gruntjs/grunt-contrib-watch/issues/145) and [#145](https://github.com/gruntjs/grunt-contrib-watch/issues/145) for more information.
 


### PR DESCRIPTION
- replace greedy !**/node_modules/** pattern with light one—!node_modules
- add note about need to add git, bower and similar folders to ignored patterns list

I improved this text in README because in my project i have 3 node_modules folder, one bower folder and git folder. When I use greedy pattern like this `!**/node_modules/••` gaze lib get 20000 files in raw in every watch loop and only 1/20 part get into addToWatched list — which is inefficient and very annoying, cause of one or two minutes delays
