### PR TITLE
Livereload option to not reload if tasks fail (fixes #84).  Also reload ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,12 @@ watch: {
 ```
 
 
+#### options.livereloadOnError
+Type: `Boolean`
+Default: `true`
+
+Option to prevent the livereload if the executed tasks encountered an error.  If set to `false`, the livereload will only be triggered if all tasks completed successfully.
+
 #### options.cwd
 Type: `String|Object`
 Default: `process.cwd()`

--- a/tasks/lib/taskrunner.js
+++ b/tasks/lib/taskrunner.js
@@ -292,7 +292,10 @@ module.exports = function(grunt) {
       grunt.task.run(self.nameArgs);
       self.running = false;
     }
+    grunt.fail.forever_warncount = 0;
+    grunt.fail.forever_errorcount = 0;
     grunt.warn = grunt.fail.warn = function(e) {
+      grunt.fail.forever_warncount ++;
       var message = typeof e === 'string' ? e : e.message;
       grunt.log.writeln(('Warning: ' + message).yellow);
       if (!grunt.option('force')) {
@@ -300,6 +303,7 @@ module.exports = function(grunt) {
       }
     };
     grunt.fatal = grunt.fail.fatal = function(e) {
+      grunt.fail.forever_errorcount ++;
       var message = typeof e === 'string' ? e : e.message;
       grunt.log.writeln(('Fatal error: ' + message).red);
       rerun();

--- a/test/fixtures/events/Gruntfile.js
+++ b/test/fixtures/events/Gruntfile.js
@@ -32,11 +32,22 @@ module.exports = function(grunt) {
       },
       targetOne: { files: ['lib/one/*.js'] },
       targetTwo: { files: ['lib/two/*.js'] },
+      changeTasks: {
+        files: ['lib/*.js'],
+        tasks: ['echo:prechange']
+      },
+    },
+    echo: {
+      prechange: { message: 'I havent changed' },
+      postchange: { message: 'Ive changed' },
     },
   });
 
   // Load this watch task
   grunt.loadTasks('../../../tasks');
+
+  // Load the echo task
+  grunt.loadTasks('../tasks');
 
   var timeout;
 
@@ -50,6 +61,10 @@ module.exports = function(grunt) {
     timeout = setTimeout(function() {
       grunt.util.exit(0);
     }, 2000);
+
+    if (target === 'changeTasks') {
+      grunt.config('watch.changeTasks.tasks',['echo:postchange']);
+    }
   });
 
 };

--- a/test/fixtures/livereload/Gruntfile.js
+++ b/test/fixtures/livereload/Gruntfile.js
@@ -59,6 +59,31 @@ module.exports = function(grunt) {
       triggerlr: {
         files: ['css/*'],
       },
+      livereloadOnErrorTrue: {
+        files: ['lib/*.js'],
+        tasks: ['iamerror'],
+        options: {
+          livereload: true
+          //normal, no flag
+        }
+      },
+      livereloadOnErrorFalse: {
+        files: ['lib/*.js'],
+        tasks: ['iamerror'],
+        options: {
+          livereload: true,
+          livereloadOnError: false
+        }
+      },
+      livereloadOnErrorFalseNoSpawn: {
+        files: ['lib/*.js'],
+        tasks: ['iamerror'],
+        options: {
+          livereload: true,
+          spawn: false,
+          livereloadOnError: false
+        },
+      },
     },
   });
 
@@ -71,5 +96,9 @@ module.exports = function(grunt) {
 
   grunt.registerTask('writecss', function() {
     grunt.file.write(path.join(__dirname, 'css', 'one.css'), '#one {}');
+  });
+
+  grunt.registerTask('iamerror', function() {
+    grunt.fail.warn('I am an error/warning');
   });
 };

--- a/test/tasks/events_test.js
+++ b/test/tasks/events_test.js
@@ -129,5 +129,19 @@ exports.events = {
       test.ok(result.indexOf('lib/two/test.js was indeed changed\ntargetTwo specifc event was fired') !== -1, 'event should have been emitted with targetTwo specified');
       test.done();
     });
-  }
+  },
+  changeTasks: function(test) {
+    test.expect(2);
+    var cwd = path.resolve(fixtures, 'events');
+    var assertWatch = helper.assertTask('watch:changeTasks', {cwd: cwd});
+    assertWatch([function() {
+      writeAll(cwd);
+    }], function(result) {
+      result = helper.unixify(result);
+      helper.verboseLog(result);
+      test.ok(result.indexOf('I havent changed') === -1, 'should not run task that was previously set');
+      test.ok(result.indexOf('Ive changed') !== -1, 'should run task set in event listener');
+      test.done();
+    });
+  },
 };

--- a/test/tasks/livereload_test.js
+++ b/test/tasks/livereload_test.js
@@ -180,4 +180,49 @@ exports.livereload = {
       test.done();
     });
   },
+  livereloadOnErrorTrue: function(test) {
+    test.expect(1);
+    var cwd = path.resolve(fixtures, 'livereload');
+    var assertWatch = helper.assertTask(['watch:livereloadOnErrorTrue', '-v'], {cwd: cwd});
+    assertWatch([function() {
+      request(35729, function(data) {
+        grunt.file.write(path.join(cwd, 'lib', 'one.js'), 'var one = true;');
+      });
+    }], function(result) {
+      result = helper.unixify(result);
+      helper.verboseLog(result);
+      test.ok(result.indexOf('Live reloading lib/one.js...') !== -1, 'Should livereload when a task errors w/o flag');
+      test.done();
+    });
+  },
+  livereloadOnErrorFalse: function(test) {
+    test.expect(1);
+    var cwd = path.resolve(fixtures, 'livereload');
+    var assertWatch = helper.assertTask(['watch:livereloadOnErrorFalse', '-v'], {cwd: cwd});
+    assertWatch([function() {
+      request(35729, function(data) {
+        grunt.file.write(path.join(cwd, 'lib', 'one.js'), 'var one = true;');
+      });
+    }], function(result) {
+      result = helper.unixify(result);
+      helper.verboseLog(result);
+      test.ok(result.indexOf('Live reloading lib/one.js...') === -1, 'Should not livereload when a task errors with flag');
+      test.done();
+    });
+  },
+  livereloadOnErrorFalseNoSpawn: function(test) {
+    test.expect(1);
+    var cwd = path.resolve(fixtures, 'livereload');
+    var assertWatch = helper.assertTask(['watch:livereloadOnErrorFalseNoSpawn', '-v'], {cwd: cwd});
+    assertWatch([function() {
+      request(35729, function(data) {
+        grunt.file.write(path.join(cwd, 'lib', 'one.js'), 'var one = true;');
+      });
+    }], function(result) {
+      result = helper.unixify(result);
+      helper.verboseLog(result);
+      test.ok(result.indexOf('Live reloading lib/one.js...') === -1, 'Should not livereload when a task errors with flag and spawn=false');
+      test.done();
+    });
+  },
 };


### PR DESCRIPTION
...configured tasks before each run.

I have the same requirement as #84.  I added an option `livereloadOnError`.  If `false` the livereload will not be triggered if any task has problems.  

Also, I have a need to dynamically configure the tasks associated with a watch in the watch event.  So I made a small change to read the tasks after each file change instead of during initialization.  This enables my use-case of being able to run a unit test associated with a changed file.  Some files don't have unit tests and if you run contrib-jasmine w/o any tests, the task logs an error, and because of the first change, will prevent livereload from triggering.

Tests included.
