### PR TITLE
Use fork of now abandoned tiny-lr.

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,11 +363,11 @@ Once installed please use the default live reload port `35729` and the browser e
 Since live reloading is used when developing, you may want to disable building for production (and are not using the browser extension). One method is to use Connect middleware to inject the script tag into your page. Try the [connect-livereload](https://github.com/intesso/connect-livereload) middleware for injecting the live reload script into your page.
 
 ##### Rolling Your Own Live Reload
-Live reloading is made easy by the library [tiny-lr](https://github.com/mklabs/tiny-lr). It is encouraged to read the documentation for `tiny-lr`. If you would like to trigger the live reload server yourself, simply POST files to the URL: `http://localhost:35729/changed`. Or if you rather roll your own live reload implementation use the following example:
+Live reloading is made easy by the library [teeny-lr](https://github.com/trevordixon/teeny-lr). It is encouraged to read the documentation for `teeny-lr`. If you would like to trigger the live reload server yourself, simply POST files to the URL: `http://localhost:35729/changed`. Or if you rather roll your own live reload implementation use the following example:
 
 ```js
 // Create a live reload server instance
-var lrserver = require('tiny-lr')();
+var lrserver = require('teeny-lr')();
 
 // Listen on port 35729
 lrserver.listen(35729, function(err) { console.log('LR Server Started'); });

--- a/docs/watch-examples.md
+++ b/docs/watch-examples.md
@@ -157,11 +157,11 @@ Once installed please use the default live reload port `35729` and the browser e
 Since live reloading is used when developing, you may want to disable building for production (and are not using the browser extension). One method is to use Connect middleware to inject the script tag into your page. Try the [connect-livereload](https://github.com/intesso/connect-livereload) middleware for injecting the live reload script into your page.
 
 ### Rolling Your Own Live Reload
-Live reloading is made easy by the library [tiny-lr](https://github.com/mklabs/tiny-lr). It is encouraged to read the documentation for `tiny-lr`. If you would like to trigger the live reload server yourself, simply POST files to the URL: `http://localhost:35729/changed`. Or if you rather roll your own live reload implementation use the following example:
+Live reloading is made easy by the library [teeny-lr](https://github.com/trevordixon/teeny-lr). It is encouraged to read the documentation for `teeny-lr`. If you would like to trigger the live reload server yourself, simply POST files to the URL: `http://localhost:35729/changed`. Or if you rather roll your own live reload implementation use the following example:
 
 ```js
 // Create a live reload server instance
-var lrserver = require('tiny-lr')();
+var lrserver = require('teeny-lr')();
 
 // Listen on port 35729
 lrserver.listen(35729, function(err) { console.log('LR Server Started'); });

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "gaze": "~0.4.0",
-    "tiny-lr": "0.0.5",
+    "teeny-lr": "0.0.6",
     "lodash": "~2.4.1",
     "async": "~0.2.9"
   },

--- a/tasks/lib/livereload.js
+++ b/tasks/lib/livereload.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-var tinylr = require('tiny-lr');
+var tinylr = require('teeny-lr');
 var _ = require('lodash');
 
 // Holds the servers out of scope in case watch is reloaded


### PR DESCRIPTION
mklabs/tiny-lr appears to be abandoned. Use this fork so it can be improved and maintained. Fixes https://github.com/gruntjs/grunt-contrib-watch/issues/290.
