### PR TITLE
Reference to enable livereload on HTML in options.livereload topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ Set to `true` or set `livereload: 1337` to a port number to enable live reloadin
 
 If enabled a live reload server will be started with the watch task per target. Then after the indicated tasks have run, the live reload server will be triggered with the modified files.
 
+See also how to [enable livereload on your HTML](https://github.com/gruntjs/grunt-contrib-watch/blob/master/docs/watch-examples.md#enabling-live-reload-in-your-html).
+
 Example:
 ```js
 watch: {

--- a/docs/watch-options.md
+++ b/docs/watch-options.md
@@ -156,6 +156,8 @@ Set to `true` or set `livereload: 1337` to a port number to enable live reloadin
 
 If enabled a live reload server will be started with the watch task per target. Then after the indicated tasks have run, the live reload server will be triggered with the modified files.
 
+See also how to [enable livereload on your HTML](https://github.com/gruntjs/grunt-contrib-watch/blob/master/docs/watch-examples.md#enabling-live-reload-in-your-html).
+
 Example:
 ```js
 watch: {


### PR DESCRIPTION
I'm not used with livereload stuff and than I didn't know what to do after enabling `option.livereload`. In a further reading - after trying crazy stuff out of the documentation - I was able to find the easy explanation on how to enable livereload on HTML.

I believe that this quick reference will help other people new to livereload use as well. 
