### PR TITLE
Emit an event when gaze has finished setting up

### DIFF
--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -82,6 +82,18 @@ module.exports = function(grunt) {
     // initialize taskrun
     var targets = taskrun.init(name, {target: target});
 
+    var targetsReady = targets.length;
+    function watcherIsReady() {
+        targetsReady--;
+
+        // Take action when all Gaze tasks report ready
+        if(targetsReady < 1) {
+            // Emit ready event if anyone is listening
+            if (grunt.event.listeners('watch-ready').length > 0) {
+                grunt.event.emit('watch-ready');
+            }
+        }
+    }
     targets.forEach(function(target, i) {
       if (typeof target.files === 'string') { target.files = [target.files]; }
 
@@ -170,12 +182,11 @@ module.exports = function(grunt) {
           if (typeof err === 'string') { err = new Error(err); }
           grunt.log.error(err.message);
         });
+
+        //
+        watcherIsReady();
       }));
     });
 
-    // Emit ready event once gaze is ready if anyone is listening
-    if (grunt.event.listeners('watch-ready').length > 0) {
-        grunt.event.emit('watch-ready');
-    }
   });
 };


### PR DESCRIPTION
Once all of the setup tasks required to react to changes on the file system are complete, emit an event. 

Use case: When watching a large number of files it can take some time to glob for all of the requested files and make the inotify request.  By watching for this event, a message can be written to the console after setup is complete and future changes will be detected.  
