### PR TITLE
Switch back to mklabs/tiny-lr

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "gaze": "~0.5.1",
-    "tiny-lr-fork": "0.0.5",
+    "tiny-lr": "~0.1.4",
     "lodash": "~2.4.1",
     "async": "~0.9.0"
   },

--- a/tasks/lib/livereload.js
+++ b/tasks/lib/livereload.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-var tinylr = require('tiny-lr-fork');
+var tinylr = require('tiny-lr');
 var _ = require('lodash');
 
 // Holds the servers out of scope in case watch is reloaded


### PR DESCRIPTION
Basically, reverts ffa27dff427e244023720c335bf4419cfadc23cb ("Use tiny-lr-fork") because the fork has been abandoned in favor of the trunk repo.
