### PR TITLE
feature: add options.runDelay

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ watch: {
 
 *For backwards compatibility the option `nospawn` is still available and will do the opposite of `spawn`.*
 
+#### options.runDelay
+Type: `Number`
+Default: 0
+
+Wait given miliseconds before run given tasks.
+
 #### options.interrupt
 Type: `Boolean`
 Default: false


### PR DESCRIPTION
Hi,

I have an express server that modify some js files.
While the process is running grunt-contrib-watch restart the server and stop the update.

This options gives express some time to do all the changes.

I know it can be done with `task: function() { ... }` but i think this is best.
