### PR TITLE
Used JSCS and fixed violations

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,3 @@
+{
+  "preset": "grunt"
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,6 +20,12 @@ module.exports = function(grunt) {
         jshintrc: '.jshintrc',
       },
     },
+    jscs: {
+      src: ['tasks/**/*.js', 'test/tasks/**/*.js'],
+      options: {
+        config: '.jscsrc'
+      }
+    },
     watch: {
       all: {
         files: ['<%= jshint.all %>'],
@@ -34,6 +40,7 @@ module.exports = function(grunt) {
   // Dynamic alias task to nodeunit. Run individual tests with: grunt test:events
   grunt.registerTask('test', function(file) {
     grunt.task.run('jshint');
+    grunt.task.run('jscs');
     grunt.config('nodeunit.tests', String(grunt.config('nodeunit.tests')).replace('*', file || '*'));
     grunt.task.run('nodeunit');
   });
@@ -43,6 +50,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-nodeunit');
   grunt.loadNpmTasks('grunt-contrib-internal');
+  grunt.loadNpmTasks('grunt-jscs');
 
   grunt.registerTask('default', ['test', 'build-contrib']);
 };

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-nodeunit": "~0.4.1",
     "grunt-contrib-internal": "~0.4.7",
-    "underscore.string": "~2.3.3"
+    "underscore.string": "~2.3.3",
+    "grunt-jscs": "~1.0.0"
   },
   "peerDependencies": {
     "grunt": "~0.4.0"

--- a/tasks/lib/livereload.js
+++ b/tasks/lib/livereload.js
@@ -16,7 +16,7 @@ var servers = Object.create(null);
 
 module.exports = function(grunt) {
 
-  var defaults = { port: 35729 };
+  var defaults = {port: 35729};
 
   function LR(options) {
     if (options === true) {

--- a/tasks/lib/taskrun.js
+++ b/tasks/lib/taskrun.js
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
     }
   }
 
-  var getErrorCount = function(){
+  var getErrorCount = function() {
     if (typeof grunt.fail.forever_warncount !== 'undefined') {
       return grunt.fail.forever_warncount + grunt.fail.forever_errorcount;
     } else {

--- a/tasks/lib/taskrunner.js
+++ b/tasks/lib/taskrunner.js
@@ -61,7 +61,7 @@ module.exports = function(grunt) {
 
     // Normalize cwd option
     if (typeof self.options.cwd === 'string') {
-      self.options.cwd = { files: self.options.cwd, spawn: self.options.cwd };
+      self.options.cwd = {files: self.options.cwd, spawn: self.options.cwd};
     }
 
     // Function to call when closing the task

--- a/test/tasks/events_test.js
+++ b/test/tasks/events_test.js
@@ -44,9 +44,12 @@ exports.events = {
     }], function(result) {
       result = helper.unixify(result);
       helper.verboseLog(result);
-      test.ok(result.indexOf('lib/added.js was indeed added') !== -1, 'event not emitted when file added');
-      test.ok(result.indexOf('lib/one.js was indeed changed') !== -1, 'event not emitted when file changed');
-      test.ok(result.indexOf('lib/added.js was indeed deleted') !== -1, 'event not emitted when file deleted');
+      test.ok(result.indexOf('lib/added.js was indeed added') !== -1,
+        'event not emitted when file added');
+      test.ok(result.indexOf('lib/one.js was indeed changed') !== -1,
+        'event not emitted when file changed');
+      test.ok(result.indexOf('lib/added.js was indeed deleted') !== -1,
+        'event not emitted when file deleted');
       test.done();
     });
   },
@@ -59,9 +62,12 @@ exports.events = {
     }], function(result) {
       result = helper.unixify(result);
       helper.verboseLog(result);
-      test.ok(result.indexOf('lib/added.js was indeed added') !== -1, 'event not emitted when file added');
-      test.ok(result.indexOf('lib/one.js was indeed changed') === -1, 'event should NOT have emitted when file changed');
-      test.ok(result.indexOf('lib/added.js was indeed deleted') === -1, 'event should NOT have emitted when file deleted');
+      test.ok(result.indexOf('lib/added.js was indeed added') !== -1,
+        'event not emitted when file added');
+      test.ok(result.indexOf('lib/one.js was indeed changed') === -1,
+        'event should NOT have emitted when file changed');
+      test.ok(result.indexOf('lib/added.js was indeed deleted') === -1,
+        'event should NOT have emitted when file deleted');
       test.done();
     });
   },
@@ -74,9 +80,12 @@ exports.events = {
     }], function(result) {
       result = helper.unixify(result);
       helper.verboseLog(result);
-      test.ok(result.indexOf('lib/added.js was indeed added') === -1, 'event should NOT have emitted when file added');
-      test.ok(result.indexOf('lib/one.js was indeed changed') !== -1, 'event should have emitted when file changed');
-      test.ok(result.indexOf('lib/added.js was indeed deleted') === -1, 'event should NOT have emitted when file deleted');
+      test.ok(result.indexOf('lib/added.js was indeed added') === -1,
+        'event should NOT have emitted when file added');
+      test.ok(result.indexOf('lib/one.js was indeed changed') !== -1,
+        'event should have emitted when file changed');
+      test.ok(result.indexOf('lib/added.js was indeed deleted') === -1,
+        'event should NOT have emitted when file deleted');
       test.done();
     });
   },
@@ -89,9 +98,12 @@ exports.events = {
     }], function(result) {
       result = helper.unixify(result);
       helper.verboseLog(result);
-      test.ok(result.indexOf('lib/added.js was indeed added') === -1, 'event should NOT have emitted when file added');
-      test.ok(result.indexOf('lib/one.js was indeed changed') === -1, 'event should NOT have emitted when file changed');
-      test.ok(result.indexOf('lib/added.js was indeed deleted') !== -1, 'event should have emitted when file deleted');
+      test.ok(result.indexOf('lib/added.js was indeed added') === -1,
+        'event should NOT have emitted when file added');
+      test.ok(result.indexOf('lib/one.js was indeed changed') === -1,
+        'event should NOT have emitted when file changed');
+      test.ok(result.indexOf('lib/added.js was indeed deleted') !== -1,
+        'event should have emitted when file deleted');
       test.done();
     });
   },
@@ -104,9 +116,13 @@ exports.events = {
     }], function(result) {
       result = helper.unixify(result);
       helper.verboseLog(result);
-      test.ok(result.indexOf('lib/added.js was indeed added') !== -1, 'event should have emitted when file added');
-      test.ok(result.indexOf('lib/one.js was indeed changed') === -1, 'event should NOT have emitted when file changed');
-      test.ok(result.indexOf('lib/added.js was indeed deleted') !== -1, 'event should have emitted when file deleted');
+      test.ok(result.indexOf('lib/added.js was indeed added') !== -1,
+        'event should have emitted when file added');
+      test.ok(result.indexOf('lib/one.js was indeed changed') === -1,
+        'event should NOT have emitted when file changed');
+      test.ok(result.indexOf('lib/added.js was indeed deleted') !== -1,
+
+        'event should have emitted when file deleted');
       test.done();
     });
   },
@@ -125,8 +141,10 @@ exports.events = {
     }], function(result) {
       result = helper.unixify(result);
       helper.verboseLog(result);
-      test.ok(result.indexOf('lib/one/test.js was indeed changed\ntargetOne specifc event was fired') !== -1, 'event should have been emitted with targetOne specified');
-      test.ok(result.indexOf('lib/two/test.js was indeed changed\ntargetTwo specifc event was fired') !== -1, 'event should have been emitted with targetTwo specified');
+      test.ok(result.indexOf('lib/one/test.js was indeed changed\ntargetOne specifc event was fired') !== -1,
+        'event should have been emitted with targetOne specified');
+      test.ok(result.indexOf('lib/two/test.js was indeed changed\ntargetTwo specifc event was fired') !== -1,
+        'event should have been emitted with targetTwo specified');
       test.done();
     });
   },

--- a/test/tasks/helper.js
+++ b/test/tasks/helper.js
@@ -90,7 +90,7 @@ helper.assertTask = function assertTask(task, options) {
 
 // clean up files within fixtures
 helper.cleanUp = function cleanUp(files) {
-  if (typeof files === 'string') files = [files];
+  if (typeof files === 'string') { files = [files]; }
   files.forEach(function(filepath) {
     filepath = path.join(helper.fixtures, filepath);
     if (grunt.file.exists(filepath)) {

--- a/test/tasks/livereload_test.js
+++ b/test/tasks/livereload_test.js
@@ -56,7 +56,8 @@ exports.livereload = {
       result = helper.unixify(result);
       helper.verboseLog(result);
       test.ok(result.indexOf('I ran before livereload.') !== -1, 'task should have ran before live reload.');
-      test.ok(result.indexOf('Live reload server started on port: 35729') !== -1, 'live reload server should have been started on port 35729.');
+      test.ok(result.indexOf('Live reload server started on port: 35729') !== -1,
+        'live reload server should have been started on port 35729.');
       test.ok(result.indexOf('Live reloading lib/one.js...') !== -1, 'live reload should have triggered on lib/one.js');
       resultData = JSON.parse(resultData);
       test.equal(resultData.tinylr, 'Welcome', 'tinylr server should have welcomed you.');
@@ -77,7 +78,8 @@ exports.livereload = {
       result = helper.unixify(result);
       helper.verboseLog(result);
       test.ok(result.indexOf('I ran before livereload.') !== -1, 'task should have ran before live reload.');
-      test.ok(result.indexOf('Live reload server started on port: 8675') !== -1, 'live reload server should have been started on port 35729.');
+      test.ok(result.indexOf('Live reload server started on port: 8675') !== -1,
+        'live reload server should have been started on port 35729.');
       test.ok(result.indexOf('Live reloading lib/one.js...') !== -1, 'live reload should have triggered on lib/one.js');
       resultData = JSON.parse(resultData);
       test.equal(resultData.tinylr, 'Welcome', 'tinylr server should have welcomed you.');
@@ -97,7 +99,8 @@ exports.livereload = {
       helper.verboseLog(result);
       test.ok(result.indexOf('Live reloading lib/one.js...') !== -1, 'live reload should have triggered on lib/one.js');
       test.ok(result.indexOf('Live reloading lib/two.js...') !== -1, 'live reload should have triggered on lib/two.js');
-      test.ok(!/Live reloading (lib\/one\.js, lib\/two.js|lib\/two.js, lib\/one.js)\.\.\./.test(result), 'live reload should have cleared js file that was already reloaded');
+      test.ok(!/Live reloading (lib\/one\.js, lib\/two.js|lib\/two.js, lib\/one.js)\.\.\./.test(result),
+        'live reload should have cleared js file that was already reloaded');
       test.done();
     });
   },
@@ -116,8 +119,10 @@ exports.livereload = {
       result = helper.unixify(result);
       helper.verboseLog(result);
       test.ok(result.indexOf('I ran before livereload.') !== -1, 'task should have ran before live reload.');
-      test.ok(result.indexOf('Live reload server started on port: 9876') !== -1, 'live reload server should have been started on port 9876.');
-      test.ok(/Live reloading (lib\/one\.js, lib\/two.js|lib\/two.js, lib\/one.js)\.\.\./.test(result), 'live reload should have triggered on lib/one.js and lib/two.js');
+      test.ok(result.indexOf('Live reload server started on port: 9876') !== -1,
+        'live reload server should have been started on port 9876.');
+      test.ok(/Live reloading (lib\/one\.js, lib\/two.js|lib\/two.js, lib\/one.js)\.\.\./.test(result),
+        'live reload should have triggered on lib/one.js and lib/two.js');
       resultData = JSON.parse(resultData);
       test.equal(resultData.tinylr, 'Welcome', 'tinylr server should have welcomed you.');
       test.done();
@@ -137,7 +142,8 @@ exports.livereload = {
       result = helper.unixify(result);
       helper.verboseLog(result);
       test.ok(result.indexOf('I ran before livereload.') !== -1, 'task should have ran before live reload.');
-      test.ok(result.indexOf('Live reload server started on port: 1337') !== -1, 'live reload server should have been started on port 1337.');
+      test.ok(result.indexOf('Live reload server started on port: 1337') !== -1,
+        'live reload server should have been started on port 1337.');
       test.ok(result.indexOf('Live reloading lib/one.js...') !== -1, 'live reload should have triggered on lib/one.js');
       resultData = JSON.parse(resultData);
       test.equal(resultData.tinylr, 'Welcome', 'tinylr server should have welcomed you.');
@@ -157,7 +163,8 @@ exports.livereload = {
     }], function(result) {
       result = helper.unixify(result);
       helper.verboseLog(result);
-      test.ok(result.indexOf('Live reload server started on port: 35729') !== -1, 'live reload server should have been started on port 35729.');
+      test.ok(result.indexOf('Live reload server started on port: 35729') !== -1,
+        'live reload server should have been started on port 35729.');
       test.ok(result.indexOf('Live reloading lib/one.js...') !== -1, 'live reload should have triggered on lib/one.js');
       resultData = JSON.parse(resultData);
       test.equal(resultData.tinylr, 'Welcome', 'tinylr server should have welcomed you.');
@@ -175,8 +182,10 @@ exports.livereload = {
     }], function(result) {
       result = helper.unixify(result);
       helper.verboseLog(result);
-      test.ok(result.indexOf('Live reloading sass/one.scss') === -1, 'Should not trigger live reload on non livereload targets.');
-      test.ok(result.indexOf('Live reloading css/one.css') !== -1, 'Should trigger live reload when other tasks trigger livereload targets.');
+      test.ok(result.indexOf('Live reloading sass/one.scss') === -1,
+        'Should not trigger live reload on non livereload targets.');
+      test.ok(result.indexOf('Live reloading css/one.css') !== -1,
+        'Should trigger live reload when other tasks trigger livereload targets.');
       test.done();
     });
   },
@@ -206,7 +215,8 @@ exports.livereload = {
     }], function(result) {
       result = helper.unixify(result);
       helper.verboseLog(result);
-      test.ok(result.indexOf('Live reloading lib/one.js...') === -1, 'Should not livereload when a task errors with flag');
+      test.ok(result.indexOf('Live reloading lib/one.js...') === -1,
+        'Should not livereload when a task errors with flag');
       test.done();
     });
   },
@@ -221,7 +231,8 @@ exports.livereload = {
     }], function(result) {
       result = helper.unixify(result);
       helper.verboseLog(result);
-      test.ok(result.indexOf('Live reloading lib/one.js...') === -1, 'Should not livereload when a task errors with flag and spawn=false');
+      test.ok(result.indexOf('Live reloading lib/one.js...') === -1,
+        'Should not livereload when a task errors with flag and spawn=false');
       test.done();
     });
   },

--- a/test/tasks/patterns_test.js
+++ b/test/tasks/patterns_test.js
@@ -34,8 +34,10 @@ exports.patterns = {
       }, 3000);
     }, function(result) {
       helper.verboseLog(result);
-      test.ok(result.indexOf('File "lib' + path.sep + 'edit.js" changed') !== -1, 'Watch should have been triggered when edit.js was edited.');
-      test.ok(result.indexOf('File "lib' + path.sep + 'dontedit.js" changed') === -1, 'Watch should NOT have been triggered when dontedit.js was edited.');
+      test.ok(result.indexOf('File "lib' + path.sep + 'edit.js" changed') !== -1,
+        'Watch should have been triggered when edit.js was edited.');
+      test.ok(result.indexOf('File "lib' + path.sep + 'dontedit.js" changed') === -1,
+        'Watch should NOT have been triggered when dontedit.js was edited.');
       test.done();
     });
   },

--- a/test/tasks/watch_test.js
+++ b/test/tasks/watch_test.js
@@ -45,7 +45,7 @@ exports.watch = {
     var cwd = path.resolve(fixtures, 'dateFormat');
     var assertWatch = helper.assertTask(['watch', '--debug'], {cwd:cwd});
     assertWatch(function() {
-       grunt.file.write(path.join(cwd, 'lib', 'one.js'), 'var one = true;');
+      grunt.file.write(path.join(cwd, 'lib', 'one.js'), 'var one = true;');
     }, function(result) {
       helper.verboseLog(result);
       test.ok(result.indexOf('dateFormat has worked!') !== -1, 'Should have displayed a custom dateFormat.');
@@ -61,7 +61,8 @@ exports.watch = {
       grunt.file.write(path.join(cwd, 'lib', 'one.js'), write);
     }, function(result) {
       helper.verboseLog(result);
-      test.ok(result.indexOf('File "lib' + path.sep + 'one.js" changed') !== -1, 'Watch should have fired when oneTarget/lib/one.js has changed.');
+      test.ok(result.indexOf('File "lib' + path.sep + 'one.js" changed') !== -1,
+        'Watch should have fired when oneTarget/lib/one.js has changed.');
       test.ok(result.indexOf('I do absolutely nothing.') !== -1, 'echo task should have fired.');
       test.done();
     });
@@ -141,7 +142,8 @@ exports.watch = {
       var interruptMatches = result.match(/have been interrupted/g);
       test.ok(interruptMatches && interruptMatches.length === 2, 'Task should have been interrupted 2 times.');
       var unInterruptMatches = result.match(/I want to be interrupted/g);
-      test.ok(unInterruptMatches && unInterruptMatches.length === 1, 'Only the last time should be working (without interruption)');
+      test.ok(unInterruptMatches && unInterruptMatches.length === 1,
+        'Only the last time should be working (without interruption)');
       test.done();
     });
   },


### PR DESCRIPTION
- Integrates grunt-jscs into the `grunt test` task.
  - Uses the `google` preset with a few rule overrides.
- Fixes violations of the styleguide

Part of the task of bringing JSCS to grunt core: https://github.com/gruntjs/grunt/issues/1247

Should eventually use the grunt preset: https://github.com/jscs-dev/node-jscs/issues/742
