### PR TITLE
Support cwd.event to emit events relative to path

### DIFF
--- a/docs/watch-options.md
+++ b/docs/watch-options.md
@@ -198,6 +198,9 @@ Default: `process.cwd()`
 
 Ability to set the current working directory. Defaults to `process.cwd()`. Can either be a string to set the cwd to match files and spawn tasks. Or an object to set each independently. Such as `options: { cwd: { files: 'match/files/from/here', spawn: 'but/spawn/files/from/here' } }`.
 
+Set `options: { cwd: { files: 'a/path', event: 'a/path' }}` to strip off `a/path` before emitting events. This option is useful for specifying the base directory to use with livereload.
+
+
 ## options.livereloadOnError
 Type: `Boolean`  
 Default: `true`  

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -95,6 +95,11 @@ module.exports = function(grunt) {
         target.options.event = [target.options.event];
       }
 
+      var eventCwd = process.cwd();
+      if (target.options.cwd && target.options.cwd.event) {
+        eventCwd = target.options.cwd.event;
+      }
+
       // Set cwd if options.cwd.file is set
       if (typeof target.options.cwd !== 'string' && target.options.cwd.files) {
         target.options.cwd = target.options.cwd.files;
@@ -128,7 +133,7 @@ module.exports = function(grunt) {
             return;
           }
 
-          filepath = path.relative(process.cwd(), filepath);
+          filepath = path.relative(eventCwd, filepath);
 
           // Skip empty filepaths
           if (filepath === '') {


### PR DESCRIPTION
This is useful for specifying the base directory to use with livereload.

Without this option, there's no way to use cwd with livereload: the path emitted is always relative to process.cwd.

I added it as a separate option to continue the pattern of separating various uses of 'cwd'.
