### PR TITLE
Fixed Readme - removed extra comma in object defs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ watch: {
     files: ['**/*.js'],
     tasks: ['jshint'],
     options: {
-      spawn: false,
+      spawn: false
     },
   },
 },
@@ -74,7 +74,7 @@ watch: {
     files: '**/*.js',
     tasks: ['jshint'],
     options: {
-      interrupt: true,
+      interrupt: true
     },
   },
 },
@@ -93,7 +93,7 @@ watch: {
     files: '**/*.js',
     tasks: ['jshint'],
     options: {
-      debounceDelay: 250,
+      debounceDelay: 250
     },
   },
 },
@@ -118,7 +118,7 @@ watch: {
     files: '**/*.js',
     tasks: ['generateFileManifest'],
     options: {
-      event: ['added', 'deleted'],
+      event: ['added', 'deleted']
     },
   },
 },
@@ -165,7 +165,7 @@ watch: {
   },
   scripts: {
     files: '**/*.js',
-    tasks: 'jshint',
+    tasks: 'jshint'
   },
 },
 ```
@@ -193,7 +193,7 @@ watch: {
     files: '**/*.sass',
     tasks: ['sass'],
     options: {
-      livereload: true,
+      livereload: true
     },
   },
 },
@@ -250,15 +250,15 @@ grunt.initConfig({
   watch: {
     gruntfile: {
       files: 'Gruntfile.js',
-      tasks: ['jshint:gruntfile'],
+      tasks: ['jshint:gruntfile']
     },
     src: {
       files: ['lib/*.js', 'css/**/*.scss', '!lib/dontwatch.js'],
-      tasks: ['default'],
+      tasks: ['default']
     },
     test: {
       files: '<%= jshint.test.src %>',
-      tasks: ['jshint:test', 'qunit'],
+      tasks: ['jshint:test', 'qunit']
     },
   },
 });
@@ -271,7 +271,7 @@ This task will emit a `watch` event when watched files are modified. This is use
 grunt.initConfig({
   watch: {
     scripts: {
-      files: ['lib/*.js'],
+      files: ['lib/*.js']
     },
   },
 });
@@ -354,7 +354,7 @@ grunt.initConfig({
       tasks: ['compass'],
       options: {
         // Start a live reload server on the default port 35729
-        livereload: true,
+        livereload: true
       },
     },
     another: {
@@ -362,12 +362,12 @@ grunt.initConfig({
       tasks: ['anothertask'],
       options: {
         // Start another live reload server on port 1337
-        livereload: 1337,
+        livereload: 1337
       },
     },
     dont: {
       files: ['other/stuff/*'],
-      tasks: ['dostuff'],
+      tasks: ['dostuff']
     },
   },
 });


### PR DESCRIPTION
The readme contains many objects in which the final key-pair value of the object is terminated with comma - there should be no comma.
