### PR TITLE
Added EMFILE error resolution to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,11 @@ This is because of your system's max opened file limit. For OSX the default is v
 
 In some versions of OSX the above solution doesn't work. In that case try `launchctl limit maxfiles 10480 10480 ` and restart your terminal. See [here](http://superuser.com/questions/261023/how-to-change-default-ulimit-values-in-mac-os-x-10-6).
 
+If you are using the Sublime Text editor, make sure you are ignoring files sublime shouldn't need to care about by adding something like the following to your User Settings JSON file:
+```
+"folder_exclude_patterns": [".svn", ".git", ".hg", "CVS", "tmp/*"] 
+```
+
 #### Can I use this with Grunt v0.3?
 `grunt-contrib-watch@0.1.x` is compatible with Grunt v0.3 but it is highly recommended to upgrade Grunt instead.
 


### PR DESCRIPTION
A [similar issue](https://github.com/stefanpenner/ember-cli/issues/2226#issuecomment-65480717) cropped up over at ember-cli, and reminded me of an issue with grunt-contrib-watch and too many open files.  Lots of people are saying this solved the for them and it seems like a better solution than increasing ulimit or altering launchctl, so I wanted to share with grunt people.
