### PR TITLE
Fix interrupt for Windows

### DIFF
--- a/tasks/lib/taskrun.js
+++ b/tasks/lib/taskrun.js
@@ -79,7 +79,7 @@ module.exports = function(grunt) {
         args: self.tasks.concat(self.options.cliArgs || []),
       }, function(err, res, code) {
         self.spawnTaskFailure = (code !== 0);
-        if (self.options.interrupt !== true || (code !== 130 && code !== 1)) {
+        if (self.options.interrupt !== true || (code !== null && code !== 130 && code !== 1)) {
           // Spawn is done
           self.spawned = null;
           done();


### PR DESCRIPTION
The interrupt feature and unit tests were failing on Windows with Node v0.10.35 and Grunt v0.4.5.  It looks like the exit code on interrupt is null, which is causing the task to be prematurely terminated.  The result is that subsequent interrupt tasks fail.

This did not appear to be an issue on OSX with the same versions of Node/Grunt installed.