### PR TITLE
Update gaze to 6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "grunt test -v"
   },
   "dependencies": {
-    "gaze": "~0.5.1",
+    "gaze": "~0.6.4",
     "tiny-lr": "~0.1.4",
     "lodash": "~2.4.1",
     "async": "~0.9.0"


### PR DESCRIPTION
Incredibly small change - but since gaze recently fixed the `emitter.setMaxListeners()` problem by defaulting to 0, this avoided all the trouble I (and others) had with the mess of too many listeners warnings when running a lot of watch processes.

Should eliminate the need for options like #354 . 