### PR TITLE
Update gaze to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "grunt test -v"
   },
   "dependencies": {
-    "gaze": "^0.5.1",
+    "gaze": "^0.6.4",
     "tiny-lr": "^0.1.4",
     "lodash": "^2.4.1",
     "async": "^0.9.0"


### PR DESCRIPTION
Hi, thank you for the great lib.

I have a performance issue on OS X. [Here](https://github.com/gruntjs/grunt-contrib-watch/issues/314#issuecomment-38647465) I read that gaze@0.6 has better support for OS X, I updated gaze and it solved my problem. So I propose to update it in the package.json file. Are there any reasons to stay on "^0.5.1"?