### PR TITLE
Security fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "gaze": "~0.5.1",
-    "tiny-lr-fork": "0.0.5",
+    "tiny-lr": "0.1.4",
     "lodash": "~2.4.1",
     "async": "~0.2.9"
   },

--- a/tasks/lib/livereload.js
+++ b/tasks/lib/livereload.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-var tinylr = require('tiny-lr-fork');
+var tinylr = require('tiny-lr');
 var _ = require('lodash');
 
 // Holds the servers out of scope in case watch is reloaded


### PR DESCRIPTION
Fixes a known security issue in `qs`. Changes were applied on top of the latest release (`v0.6.1`) so that this can be released as a separate version (e.g. can't be merged into master) until later changes land (e.g. `v0.7.0`). Closes https://github.com/gruntjs/grunt-contrib-watch/issues/399. Thanks! :tada:
```txt
❯ requiresafe check
Name  Installed           Patched  Location                                 Advisory Details
qs        0.5.6  >=1.0.0, >=1.0.0  grunt-contrib-watch > tiny-lr-fork > qs  https://portal.requiresafe.com/advisories/qs_dos_memory_exhaustion https://portal.requiresafe.com/advisories/qs_dos_extended_event_loop_blocking
```
## Changes
- __deps__: replaced `tiny-lr-fork` with `tiny-lr` which closes a security issue in `qs`