### PR TITLE
Adds 'watch-start' and 'watch-end' events

### DIFF
--- a/docs/watch-examples.md
+++ b/docs/watch-examples.md
@@ -46,6 +46,18 @@ grunt.event.on('watch', function(action, filepath, target) {
 });
 ```
 
+Simple events are also available for 'watch-start' and 'watch-end'. These will fire before/after your watch tasks have run. Here is a simple example of using the `watch-start` and `watch-end` events.
+
+```js
+grunt.event.on('watch-start', function() {
+  grunt.log.writeln('Watch tasks are about to be run!');
+});
+
+grunt.event.on('watch-end', function() {
+  grunt.log.writeln('Watch tasks are finished running!');
+});
+```
+
 **The `watch` event is not intended for replacing the standard Grunt API for configuring and running tasks. If you're trying to run tasks from within the `watch` event you're more than likely doing it wrong. Please read [configuring tasks](http://gruntjs.com/configuring-tasks).**
 
 ### Compiling Files As Needed

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -30,6 +30,10 @@ module.exports = function(grunt) {
 
   // When task runner has started
   taskrun.on('start', function() {
+    if (grunt.event.listeners('watch-start').length > 0) {
+      grunt.event.emit('watch-start');
+    }
+
     Object.keys(changedFiles).forEach(function(filepath) {
       // Log which file has changed, and how.
       grunt.log.ok('File "' + filepath + '" ' + changedFiles[filepath] + '.');
@@ -40,6 +44,10 @@ module.exports = function(grunt) {
 
   // When task runner has ended
   taskrun.on('end', function(time) {
+    if (grunt.event.listeners('watch-end').length > 0) {
+      grunt.event.emit('watch-end');
+    }
+
     if (time > 0) {
       dateFormat(time);
     }

--- a/test/fixtures/events/Gruntfile.js
+++ b/test/fixtures/events/Gruntfile.js
@@ -67,4 +67,12 @@ module.exports = function(grunt) {
     }
   });
 
+  grunt.event.on('watch-start', function() {
+    grunt.log.writeln('watch started');
+  });
+
+  grunt.event.on('watch-end', function() {
+    grunt.log.writeln('watch ended');
+  });
+
 };

--- a/test/tasks/events_test.js
+++ b/test/tasks/events_test.js
@@ -162,4 +162,21 @@ exports.events = {
       test.done();
     });
   },
+  watchStartEnd: function(test) {
+    test.expect(5);
+    var cwd = path.resolve(fixtures, 'events');
+    var assertWatch = helper.assertTask('watch:all', {cwd: cwd});
+    assertWatch([function() {
+      writeAll(cwd);
+    }], function(result) {
+      result = helper.unixify(result);
+      helper.verboseLog(result);
+      test.ok(/watch started/.test(result), 'event not emitted when watch started');
+      test.ok(/watch ended/.test(result), 'event not emitted when watch ended');
+      test.ok(result.indexOf('watch started') < result.indexOf('watch ended'), 'start event fired after watch event');
+      test.ok(result.indexOf('watch started') < result.indexOf('>> File'), 'watch-started fired late');
+      test.ok(result.indexOf('>> File') < result.indexOf('watch ended'), 'watch-ended fired early');
+      test.done();
+    });
+  }
 };


### PR DESCRIPTION
Built the functionality I was looking for in this issue: https://github.com/gruntjs/grunt-contrib-watch/issues/437

Changes make grunt events to be emitted for:
`watch-start`: Fires right before watch tasks begin
`watch-end`: Fires right after all tasks have completed
