### PR TITLE
Update logging to be less verbose

### DIFF
--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -30,9 +30,25 @@ module.exports = function(grunt) {
 
   // When task runner has started
   taskrun.on('start', function() {
-    Object.keys(changedFiles).forEach(function(filepath) {
+    var changed = Object.keys(changedFiles);
+    var changedHow = {};
+    changed.forEach(function(filepath) {
+      var how = changedFiles[filepath];
       // Log which file has changed, and how.
-      grunt.log.ok('File "' + filepath + '" ' + changedFiles[filepath] + '.');
+      grunt.verbose.writeln('File "' + filepath + '" ' + how + '.');
+      if (typeof changedHow[how] === 'undefined') {
+        changedHow[how] = 0;
+      }
+      changedHow[how]++;
+    });
+    Object.keys(changedHow).forEach(function(how) {
+      if (changedHow[how] > 0) {
+        grunt.log.ok(
+          changedHow[how] + ' ' +
+          grunt.util.pluralize(changedHow[how], 'file/files') +
+          ' ' + how + '.'
+        );
+      }
     });
     // Reset changedFiles
     changedFiles = Object.create(null);

--- a/test/tasks/patterns_test.js
+++ b/test/tasks/patterns_test.js
@@ -23,10 +23,10 @@ exports.patterns = {
     cleanUp();
     done();
   },
-  negate: function(test) {
+  negateVerbose: function(test) {
     test.expect(2);
     var cwd = path.resolve(fixtures, 'patterns');
-    var assertWatch = helper.assertTask('watch', {cwd: cwd});
+    var assertWatch = helper.assertTask('watch', {cwd: cwd, verbose: true});
     assertWatch(function() {
       grunt.file.write(path.join(cwd, 'lib', 'sub', 'dontedit.js'), 'var dontedit = true;');
       setTimeout(function() {
@@ -38,6 +38,21 @@ exports.patterns = {
         'Watch should have been triggered when edit.js was edited.');
       test.ok(result.indexOf('File "lib' + path.sep + 'dontedit.js" changed') === -1,
         'Watch should NOT have been triggered when dontedit.js was edited.');
+      test.done();
+    });
+  },
+  negate: function(test) {
+    test.expect(1);
+    var cwd = path.resolve(fixtures, 'patterns');
+    var assertWatch = helper.assertTask('watch', {cwd: cwd});
+    assertWatch(function() {
+      grunt.file.write(path.join(cwd, 'lib', 'sub', 'dontedit.js'), 'var dontedit = true;');
+      setTimeout(function() {
+        grunt.file.write(path.join(cwd, 'lib', 'edit.js'), 'var edit = true;');
+      }, 3000);
+    }, function(result) {
+      test.ok(result.indexOf('1 file changed.') !== -1,
+        'Watch should have been triggered when edit.js was edited.');
       test.done();
     });
   },

--- a/test/tasks/watch_test.js
+++ b/test/tasks/watch_test.js
@@ -61,7 +61,7 @@ exports.watch = {
       grunt.file.write(path.join(cwd, 'lib', 'one.js'), write);
     }, function(result) {
       helper.verboseLog(result);
-      test.ok(result.indexOf('File "lib' + path.sep + 'one.js" changed') !== -1,
+      test.ok(result.indexOf('1 file changed.') !== -1,
         'Watch should have fired when oneTarget/lib/one.js has changed.');
       test.ok(result.indexOf('I do absolutely nothing.') !== -1, 'echo task should have fired.');
       test.done();


### PR DESCRIPTION
Instead of showing all the files that have changed, state how many have
changed (per change type) unless verbose is passed. Then display all the
changes.
