### PR TITLE
Fix livereload on npm v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,8 @@ Default: `process.cwd()`
 Ability to set the current working directory. Defaults to `process.cwd()`. Can either be a string to set the cwd to match files and spawn tasks. Or an object to set each independently. Such as `options: { cwd: { files: 'match/files/from/here', spawn: 'but/spawn/files/from/here' } }`.
 
 #### options.livereloadOnError
-Type: `Boolean`  
-Default: `true`  
+Type: `Boolean`
+Default: `true`
 
 Option to prevent the livereload if the executed tasks encountered an error.  If set to `false`, the livereload will only be triggered if all tasks completed successfully.
 
@@ -391,11 +391,11 @@ Once installed please use the default live reload port `35729` and the browser e
 Since live reloading is used when developing, you may want to disable building for production (and are not using the browser extension). One method is to use Connect middleware to inject the script tag into your page. Try the [connect-livereload](https://github.com/intesso/connect-livereload) middleware for injecting the live reload script into your page.
 
 ##### Rolling Your Own Live Reload
-Live reloading is made easy by the library [tiny-lr](https://github.com/mklabs/tiny-lr). It is encouraged to read the documentation for `tiny-lr`. If you would like to trigger the live reload server yourself, simply POST files to the URL: `http://localhost:35729/changed`. Or if you rather roll your own live reload implementation use the following example:
+Live reloading is made easy by the library [mini-lr](https://github.com/elwayman02/mini-lr). It is encouraged to read the documentation for `mini-lr`. If you would like to trigger the live reload server yourself, simply POST files to the URL: `http://localhost:35729/changed`. Or if you rather roll your own live reload implementation use the following example:
 
 ```js
 // Create a live reload server instance
-var lrserver = require('tiny-lr')();
+var lrserver = require('mini-lr')();
 
 // Listen on port 35729
 lrserver.listen(35729, function(err) { console.log('LR Server Started'); });

--- a/docs/watch-examples.md
+++ b/docs/watch-examples.md
@@ -157,11 +157,11 @@ Once installed please use the default live reload port `35729` and the browser e
 Since live reloading is used when developing, you may want to disable building for production (and are not using the browser extension). One method is to use Connect middleware to inject the script tag into your page. Try the [connect-livereload](https://github.com/intesso/connect-livereload) middleware for injecting the live reload script into your page.
 
 ### Rolling Your Own Live Reload
-Live reloading is made easy by the library [tiny-lr](https://github.com/mklabs/tiny-lr). It is encouraged to read the documentation for `tiny-lr`. If you would like to trigger the live reload server yourself, simply POST files to the URL: `http://localhost:35729/changed`. Or if you rather roll your own live reload implementation use the following example:
+Live reloading is made easy by the library [mini-lr](https://github.com/elwayman02/mini-lr). It is encouraged to read the documentation for `mini-lr`. If you would like to trigger the live reload server yourself, simply POST files to the URL: `http://localhost:35729/changed`. Or if you rather roll your own live reload implementation use the following example:
 
 ```js
 // Create a live reload server instance
-var lrserver = require('tiny-lr')();
+var lrserver = require('mini-lr')();
 
 // Listen on port 35729
 lrserver.listen(35729, function(err) { console.log('LR Server Started'); });

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "test": "grunt test -v"
   },
   "dependencies": {
+    "async": "^0.9.0",
     "gaze": "^0.5.1",
-    "tiny-lr": "^0.1.4",
     "lodash": "^2.4.1",
-    "async": "^0.9.0"
+    "mini-lr": "^0.1.8"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/tasks/lib/livereload.js
+++ b/tasks/lib/livereload.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-var tinylr = require('tiny-lr');
+var minilr = require('mini-lr');
 var _ = require('lodash');
 
 // Holds the servers out of scope in case watch is reloaded
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
     if (servers[host]) {
       this.server = servers[host];
     } else {
-      this.server = tinylr(options);
+      this.server = minilr(options);
       this.server.server.removeAllListeners('error');
       this.server.server.on('error', function(err) {
         if (err.code === 'EADDRINUSE') {

--- a/test/tasks/livereload_test.js
+++ b/test/tasks/livereload_test.js
@@ -60,7 +60,7 @@ exports.livereload = {
         'live reload server should have been started on port 35729.');
       test.ok(result.indexOf('Live reloading lib/one.js...') !== -1, 'live reload should have triggered on lib/one.js');
       resultData = JSON.parse(resultData);
-      test.equal(resultData.tinylr, 'Welcome', 'tinylr server should have welcomed you.');
+      test.equal(resultData.minilr, 'Welcome', 'minilr server should have welcomed you.');
       test.done();
     });
   },
@@ -82,7 +82,7 @@ exports.livereload = {
         'live reload server should have been started on localhost:8675.');
       test.ok(result.indexOf('Live reloading lib/one.js...') !== -1, 'live reload should have triggered on lib/one.js');
       resultData = JSON.parse(resultData);
-      test.equal(resultData.tinylr, 'Welcome', 'tinylr server should have welcomed you.');
+      test.equal(resultData.minilr, 'Welcome', 'minilr server should have welcomed you.');
       test.done();
     });
   },
@@ -124,7 +124,7 @@ exports.livereload = {
       test.ok(/Live reloading (lib\/one\.js, lib\/two.js|lib\/two.js, lib\/one.js)\.\.\./.test(result),
         'live reload should have triggered on lib/one.js and lib/two.js');
       resultData = JSON.parse(resultData);
-      test.equal(resultData.tinylr, 'Welcome', 'tinylr server should have welcomed you.');
+      test.equal(resultData.minilr, 'Welcome', 'minilr server should have welcomed you.');
       test.done();
     });
   },
@@ -146,7 +146,7 @@ exports.livereload = {
         'live reload server should have been started on port 1337.');
       test.ok(result.indexOf('Live reloading lib/one.js...') !== -1, 'live reload should have triggered on lib/one.js');
       resultData = JSON.parse(resultData);
-      test.equal(resultData.tinylr, 'Welcome', 'tinylr server should have welcomed you.');
+      test.equal(resultData.minilr, 'Welcome', 'minilr server should have welcomed you.');
       test.done();
     });
   },
@@ -167,7 +167,7 @@ exports.livereload = {
         'live reload server should have been started on port 35729.');
       test.ok(result.indexOf('Live reloading lib/one.js...') !== -1, 'live reload should have triggered on lib/one.js');
       resultData = JSON.parse(resultData);
-      test.equal(resultData.tinylr, 'Welcome', 'tinylr server should have welcomed you.');
+      test.equal(resultData.minilr, 'Welcome', 'minilr server should have welcomed you.');
       test.done();
     });
   },


### PR DESCRIPTION
The tiny-lr project has seemingly been abandoned and no new release has been cut for months to provide the support for npm v3. As such, I've forked the project and released mini-lr moving forward.

More Info: https://github.com/mklabs/tiny-lr/issues/91

There are two failing tests on the master branch that still exist here, not related to my changes.