### PR TITLE
Allow muting log messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,14 @@ Default: `true`
 
 Option to prevent the livereload if the executed tasks encountered an error.  If set to `false`, the livereload will only be triggered if all tasks completed successfully.
 
+#### options.silently
+Type: `Boolean`
+Default: `false`
+
+Option to mute log messages. Ignored when running grunt in verbose mode.
+
+This is *only a task level option* and cannot be configured per target.
+
 ### Examples
 
 ```js

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -18,9 +18,14 @@ module.exports = function(grunt) {
 
   var taskrun = require('./lib/taskrunner')(grunt);
 
+  // Default or verbose logger
+  var logger = function() {
+    return taskrun.options.silently ? grunt.verbose : grunt.log;
+  };
+
   // Default date format logged
   var dateFormat = function(time) {
-    grunt.log.writeln(String(
+    logger().writeln(String(
       'Completed in ' +
       time.toFixed(3) +
       's at ' +
@@ -32,7 +37,7 @@ module.exports = function(grunt) {
   taskrun.on('start', function() {
     Object.keys(changedFiles).forEach(function(filepath) {
       // Log which file has changed, and how.
-      grunt.log.ok('File "' + filepath + '" ' + changedFiles[filepath] + '.');
+      logger().ok('File "' + filepath + '" ' + changedFiles[filepath] + '.');
     });
     // Reset changedFiles
     changedFiles = Object.create(null);
@@ -77,7 +82,7 @@ module.exports = function(grunt) {
       dateFormat = df;
     }
 
-    if (taskrun.running === false) { grunt.log.writeln(waiting); }
+    if (taskrun.running === false) { logger().writeln(waiting); }
 
     // Initialize taskrun
     var targets = taskrun.init(name, {target: target});


### PR DESCRIPTION
Mute output by providing task level option `silently: true`. When grunt
runs in verbose mode (e.g. `--verbose` command line option) output is
always logged no matter if the option is set.

Cleans up console output considerably, especially when providing a separate
watch target for live reloading.