### PR TITLE
Updated tiny-lr to avoid vulnerability in qs

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "gaze": "^0.5.1",
-    "tiny-lr": "^0.1.4",
+    "tiny-lr": "^0.2.1",
     "lodash": "^2.4.1",
     "async": "^0.9.0"
   },


### PR DESCRIPTION
tiny-lr needs to be updated to update its sub-dependency qs.  See https://nodesecurity.io/advisories/29.

BTW-- I tried running the tests.  Both with this change and without this change the same two tests were failing, but perhaps that is something to do with my environment.