### PR TITLE
Updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,18 +16,18 @@
   },
   "dependencies": {
     "gaze": "^0.5.1",
-    "tiny-lr": "^0.1.4",
-    "lodash": "^2.4.1",
-    "async": "^0.9.0"
+    "tiny-lr": "^0.2.1",
+    "lodash": "^3.10.1",
+    "async": "^1.5.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-internal": "^0.4.7",
-    "grunt-contrib-jshint": "^0.10.0",
+    "grunt-contrib-jshint": "^0.11.3",
     "grunt-contrib-nodeunit": "^0.4.1",
     "grunt-jscs": "^2.1.0",
-    "underscore.string": "^2.3.3"
+    "underscore.string": "^3.2.2"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"


### PR DESCRIPTION
Pull request only updates dependencies not covered by existing semver declared version ranges.

• Not sure why https://github.com/gruntjs/grunt-contrib-watch/pull/474 was closed as this in one of the reasons I've created this pull request.

• Also doesn't touch the Gaze dependency mentioned in https://github.com/gruntjs/grunt-contrib-watch/pull/412

The same two tests fail before and after updating the dependencies:
```
ERROR
>> Message: Task should have been interrupted 2 times.
>> Error: false == true
>> at Object.ok (node_modules/nodeunit/lib/types.js:83:39)
>> at /Users/netweb/dev/github-ntwb-grunt-contrib-watch/test/tasks/watch_test.js:143:12
>> at ChildProcess.<anonymous> (test/tasks/helper.js:84:7)
>> at emitTwo (events.js:87:13)
>> at ChildProcess.emit (events.js:172:7)
>> at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)

>> Message: Only the last time should be working (without interruption)
>> Error: null == true
>> at Object.ok (node_modules/nodeunit/lib/types.js:83:39)
>> at /Users/netweb/dev/github-ntwb-grunt-contrib-watch/test/tasks/watch_test.js:145:12
>> at ChildProcess.<anonymous> (test/tasks/helper.js:84:7)
>> at emitTwo (events.js:87:13)
>> at ChildProcess.emit (events.js:172:7)
>> at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)
```
