### PR TITLE
Fix for "nospawn + interrupt causes watch to end"

### DIFF
--- a/tasks/lib/taskrunner.js
+++ b/tasks/lib/taskrunner.js
@@ -316,7 +316,7 @@ module.exports = function(grunt) {
   Runner.prototype.interrupt = function interrupt() {
     var self = this;
     self._completeQueue();
-    grunt.task.clearQueue();
+    grunt.task.clearQueue({untilMarker: true});
     self.emit('interrupt');
   };
 


### PR DESCRIPTION
This fixes #377 for me (Windows 7, Grunt 0.4.5, Node 5.9.0).
