### PR TITLE
Fix to #508, #494...: some grunt tasks not triggered when spawn:false

### DIFF
--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -61,7 +61,11 @@ module.exports = function(grunt) {
     var self = this;
     var name = self.name || 'watch';
 
-    // keep track of previous watchers to delete them later
+    // As the context may have changed, it might be necessary
+    // to recreate the watchers. However, we do not delete
+    // the previous watchers immediately, or we take the
+    // risk to miss changes in the file system.
+    // Hence, keep track of previous watchers to delete them after
     var previousWatchers = watchers;
     watchers = [];
 
@@ -185,7 +189,7 @@ module.exports = function(grunt) {
       }));
     });
     // Close any previously opened watchers
-    prevousWatchers.forEach(function(watcher) {
+    previousWatchers.forEach(function(watcher) {
       watcher.close();
     });
   });

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -61,10 +61,8 @@ module.exports = function(grunt) {
     var self = this;
     var name = self.name || 'watch';
 
-    // Close any previously opened watchers
-    watchers.forEach(function(watcher) {
-      watcher.close();
-    });
+    // keep track of previous watchers to delete them later
+    var previousWatchers = watchers;
     watchers = [];
 
     // Never gonna give you up, never gonna let you down
@@ -186,6 +184,9 @@ module.exports = function(grunt) {
         });
       }));
     });
-
+    // Close any previously opened watchers
+    prevousWatchers.forEach(function(watcher) {
+      watcher.close();
+    });
   });
 };


### PR DESCRIPTION
The issues described in the #508, #494  and some others, occur when spawn is set to false.

In that case, the watchers are deleted and then re-created once the triggered tasks have completed their execution. 

The re-creation of the watchers is a good idea, since this makes sure to take into account any change that could have happened in the file system (e.g. new repositories) or in the watch options while the triggered tasks were run.

However, when the triggered tasks make some changes to the watched files, it might happen that the changes are not detected because they happen just between the time the watchers are deleted and the time the new watchers are created: at the exact moment the changes are done to the file system, there is no watcher listening to the change. Hence, watch doesn't trigger tasks.

The fix consists in doing the deletion of the previous watchers once the watchers have been recreated. This way, there is always at least one watcher listening to file system changes.
