### PR TITLE
Fix to issue #510 Watch doesn't detect cascading changes when nospawn is true

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "grunt-contrib-internal": "^0.4.14",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-nodeunit": "^1.0.0",
+    "grunt-contrib-copy": "*",
     "grunt-jscs": "^2.8.0",
     "underscore.string": "^3.2.2"
   },

--- a/test/fixtures/nospawn/Gruntfile.js
+++ b/test/fixtures/nospawn/Gruntfile.js
@@ -4,7 +4,15 @@ module.exports = function(grunt) {
   var http = require('http');
   var port = 1337;
 
+  grunt.loadNpmTasks('grunt-contrib-copy');
+
   grunt.initConfig({
+    copy: {
+      cascade: {
+          src: 'lib/source.js',
+          dest: 'lib/destination.js',
+      },
+    },
     watch: {
       nospawn: {
         files: ['lib/nospawn.js'],
@@ -16,6 +24,16 @@ module.exports = function(grunt) {
       spawn: {
         files: ['lib/spawn.js'],
         tasks: ['server'],
+      },
+      cascading: {
+        files: ['lib/source.js'],
+        tasks: ['copy:cascade'],
+        options: {
+          nospawn: true,
+        },
+      },
+      cascaded: {
+        files: ['lib/destination.js'],
       },
       interrupt: {
         files: ['lib/interrupt.js'],

--- a/test/tasks/nospawn_test.js
+++ b/test/tasks/nospawn_test.js
@@ -62,4 +62,18 @@ exports.nospawn = {
       test.done();
     });
   },
+  cascading: function(test) {
+    test.expect(2);
+    var cwd = path.resolve(fixtures, 'nospawn');
+    var assertWatch = helper.assertTask('watch', {cwd: cwd});
+    assertWatch(function() {
+      var write = 'var cascading = true;';
+      grunt.file.write(path.join(cwd, 'lib', 'source.js'), write);
+    }, function(result) {
+      helper.verboseLog(result);
+      test.ok(result.indexOf('File "lib/source.js" changed') !== -1, 'Cascading file should have been detected.');
+      test.ok(result.indexOf('File "lib/destination.js" changed') !== -1, 'Cascaded file should have been detected.');
+      test.done();
+    });
+  },
 };


### PR DESCRIPTION
This fixes issue #510, by keeping the watchers when the task is running (i.e. when `nospawn` is used). In `spawn` mode, the watchers are closed and recreated as before.

I have added a test suite in `nospawn_test.js`, which uses `grunt-contrib-copy`. The test creates a `source.js` file, which is copied into `destination.js`. Without the fix, the creation of `source.js` is correctly detected by watch, not the creation of `destination.js`.

The full test suite passes, apart from watch: interrupt, which anyway doesn't work on my platform (raspberry pi2).

Hope that helps!
