### PR TITLE
Watch only fires when patterns match

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "grunt-contrib-watch",
+  "name": "@medic/grunt-contrib-watch",
   "description": "Run predefined tasks whenever watched file patterns are added, changed or deleted",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Grunt Team",
     "url": "http://gruntjs.com/"
   },
-  "repository": "gruntjs/grunt-contrib-watch",
+  "repository": "scdf/grunt-contrib-watch",
   "license": "MIT",
   "engines": {
     "node": ">=0.10.0"

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -11,6 +11,7 @@
 var path = require('path');
 var Gaze = require('gaze').Gaze;
 var _ = require('lodash');
+var globule = require('globule');
 var waiting = 'Waiting...';
 var changedFiles = Object.create(null);
 var watchers = [];
@@ -144,6 +145,11 @@ module.exports = function(grunt) {
 
           // Skip empty filepaths
           if (filepath === '') {
+            return;
+          }
+
+          // Skip non matching hits caused by Gaze on some systems
+          if (!globule.isMatch(patterns, filepath)) {
             return;
           }
 


### PR DESCRIPTION
Fixes issues with Gaze sending incorrect hits on some systems (tested on OSX). An example of this is creating directories in the same folder as a watched file.
