### PR TITLE
Update tiny-lr dependency to 1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "async": "^1.5.0",
     "gaze": "^1.1.0",
     "lodash": "^4.0.0",
-    "tiny-lr": "^0.2.1"
+    "tiny-lr": "^1.0.4"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
Fixes #530 and also addresses https://snyk.io/vuln/npm:ms:20170412
because `tiny-lr@1` has eliminated its former `body-parser` dependency.

Test suite is passing locally with this update.

Tracking: https://github.com/digitalbazaar/bedrock-test/pull/3