### PR TITLE
update Node.js versions used in AppVeyor and Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ sudo: false
 language: node_js
 
 node_js:
-  - "4"
-  - "6"
-  - "8"
-  - "9"
+  - "10"
+  - "12"
+  - "14"
+  - "15"
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
   - "10"
   - "12"
   - "14"
-  - "15"
+  - "16"
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
       platform: x86
     - nodejs_version: "14"
       platform: x86
-    - nodejs_version: "15"
+    - nodejs_version: "16"
       platform: x86
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,15 +5,15 @@ version: "{build}"
 # What combinations to test
 environment:
   matrix:
-    - nodejs_version: "4"
+    - nodejs_version: "10"
       platform: x64
-    - nodejs_version: "4"
+    - nodejs_version: "10"
       platform: x86
-    - nodejs_version: "6"
+    - nodejs_version: "12"
       platform: x86
-    - nodejs_version: "8"
+    - nodejs_version: "14"
       platform: x86
-    - nodejs_version: "9"
+    - nodejs_version: "15"
       platform: x86
 
 install:


### PR DESCRIPTION
Node.js versions below 10.x are not maintained anymore, so it is probably best to use some newer, still maintained versions.
For release cyles of Node.js see the official site: <https://nodejs.org/en/about/releases/>.