### PR TITLE
Added missing event(in options.event) in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The `interval` is passed to `fs.watchFile`. Since `interval` is only used by `fs
 Type: `String|Array`  
 Default: `'all'`
 
-Specify the type of watch events that triggers the specified task. This option can be one or many of: `'all'`, `'changed'`, `'added'` and `'deleted'`.
+Specify the type of watch events that triggers the specified task. This option can be one or many of: `'all'`, `'changed'`, `'added'`, `'renamed'` and `'deleted'`.
 
 Example:
 ```js


### PR DESCRIPTION
**TLDR:** Added `renamed` event for options.event's documentation.

**What:** The `renamed` event isn't mentioned in the options.event documentation. This event is triggered when a watched file name is changed. Here's a screenshot of what it looks like when the event is triggered:-

<img width="511" alt="Screenshot 2022-09-05 at 10 07 20 PM" src="https://user-images.githubusercontent.com/22625661/188490339-7cbca972-a7f1-45b4-9c1c-5e279587754a.png">

The code logic for this event is already working correctly. Just the documentation isn't updated.